### PR TITLE
fix: change from "startup" and "shutdown" events to lifespan

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID
 
 from src.config import settings
-from src.constants import DB_NAMING_CONVENTION, Environment
+from src.constants import DB_NAMING_CONVENTION
 
 DATABASE_URL = settings.DATABASE_URL
 


### PR DESCRIPTION
This pull request addresses issue #4 and introduces changes to the `startup` and `shutdown` events which were replaced by a lifespan async context manager.