### PR TITLE
chore: Update Redis Dependency and Refactor Async Imports

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-aioredis==2.0.1
+redis==4.5.5
 alembic==1.9.1
 bcrypt
 databases[asyncpg]==0.7.0

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,9 @@
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
-import aioredis
 import sentry_sdk
 from fastapi import FastAPI
+from redis import asyncio as aioredis
 from starlette.middleware.cors import CORSMiddleware
 
 from src import redis

--- a/src/redis.py
+++ b/src/redis.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 from typing import Optional
 
-from aioredis import Redis
-
+from redis.asyncio import Redis
 from src.models import ORJSONModel
 
 redis_client: Redis = None  # type: ignore


### PR DESCRIPTION
## Summary
- Replace `aioredis==2.0.1` with `redis==4.5.5`
- Migrate Redis imports to utilize the `asyncio` module in the `redis` package

## Rationale
The `aioredis` package is deprecated and not advised for use with Python 3.11. It has been superseded by the `redis` library, which includes necessary async support.

See https://github.com/aio-libs/aioredis-py/issues/1409 and https://github.com/aio-libs/aioredis-py/pull/1302/files for details.
