### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 JWT_ALG=HS256
 JWT_EXP=21000
 JWT_SECRET=SECRET
-DATABASE_URL=postgresql://app:app@app_db:5432/app
+DATABASE_URL=postgresql+asyncpg://app:app@app_db:5432/app
 REDIS_URL=redis://:myStrongPassword@redis:6379
 
 SITE_DOMAIN=127.0.0.1


### PR DESCRIPTION
I updated the DATABASE_URL line in the .env.example file to use the asyncpg driver like it used on pytest.init, since when you follow the tutorial by `cp .env.example .env` you run to the problem 

```
app     |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
app     |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
app     |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
app     |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
app     |   File "/src/src/main.py", line 8, in <module>
app     |     from src.auth.router import router as auth_router
app     |   File "/src/src/auth/router.py", line 5, in <module>
app     |     from src.auth import jwt, service, utils
app     |   File "/src/src/auth/service.py", line 13, in <module>
app     |     from src.database import auth_user, execute, fetch_one, refresh_tokens
app     |   File "/src/src/database.py", line 28, in <module>
app     |     engine = create_async_engine(DATABASE_URL)
app     |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 118, in create_async_engine
app     |     return AsyncEngine(sync_engine)
app     |   File "/usr/local/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 1027, in __init__
app     |     raise exc.InvalidRequestError(
app     | sqlalchemy.exc.InvalidRequestError: The asyncio extension requires an async driver to be used. The loaded 'psycopg2' is not async.
```