### PR TITLE
fix async redis import

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
-import redis as aioredis
+import redis.asyncio as aioredis
 import sentry_sdk
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware


### PR DESCRIPTION
I was in the process of updating my FastAPI apps according to your new updates in this repo but faced issues with Redis. After hours of googling I found out that the async redis was imported incorrectly. For now, everything works fine for me and I assume this is a real bug.