### PR TITLE
New shortcut that shows docker-compose logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,11 @@ ENVIRONMENT=LOCAL
 
 CORS_HEADERS=["*"]
 CORS_ORIGINS=["http://localhost:3000"]
+
+
+# postgres variables, must be the same as in DATABASE_URL
+POSTGRES_USER=app
+POSTGRES_PASSWORD=app
+POSTGRES_HOST=app_db
+POSTGRES_PORT=5432
+POSTGRES_DB=app

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Backup has been created and saved to /backups/backup-year-month-date-HHMMSS.dump
 
 - Copy the backup file or a directory with all backups to your local machine
 ```shell
-just get-backup  # get all backups
-just get-backup backup-year-month-date-HHMMSS.dump.gz  # get a specific backup
+just mount-docker-backup  # get all backups
+just mount-docker-backup backup-year-month-date-HHMMSS.dump.gz  # get a specific backup
 ```
 - Restore
 ```shell

--- a/README.md
+++ b/README.md
@@ -64,3 +64,13 @@ Run tests
 ```shell
 docker compose exec app pytest
 ```
+### Justfile
+The template is using [Just](https://github.com/casey/just). 
+
+It's a Makefile alternative written in Rust with a nice syntax.
+
+You can find all the shortcuts in `justfile` or run the following command to list them all:
+```shell
+just --list
+```
+Info about installation can be found [here](https://github.com/casey/just#packages).

--- a/README.md
+++ b/README.md
@@ -74,3 +74,27 @@ You can find all the shortcuts in `justfile` or run the following command to lis
 just --list
 ```
 Info about installation can be found [here](https://github.com/casey/just#packages).
+### Backup and Restore database
+We are using `pg_dump` and `pg_restore` to backup and restore the database.
+- Backup
+```shell
+just backup
+# output example
+Backup process started.
+Backup has been created and saved to /backups/backup-year-month-date-HHMMSS.dump.gz
+```
+
+- Copy the backup file or a directory with all backups to your local machine
+```shell
+just get-backup  # get all backups
+just get-backup backup-year-month-date-HHMMSS.dump.gz  # get a specific backup
+```
+- Restore
+```shell
+just restore backup-year-month-date-HHMMSS.dump.gz
+# output example
+Dropping the database...
+Creating a new database...
+Applying the backup to the new database...
+Backup applied successfully.
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,12 @@ services:
     container_name: app_db
     hostname: app_db
     image: library/postgres:14.1
-    environment:
-      - POSTGRES_USER=app
-      - POSTGRES_PASSWORD=app
-      - POSTGRES_DB=app
+    env_file:
+      - .env
     volumes:
       - app_pg_data:/var/lib/postgresql/data
+      - app_pg_data_backups:/backups
+      - ./scripts/postgres:/scripts
     ports:
       - "65432:5432"
 
@@ -41,6 +41,8 @@ services:
 
 volumes:
   app_pg_data:
+    driver: "local"
+  app_pg_data_backups:
     driver: "local"
 
 networks:

--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ backup:
 # examples:
 # "just get-backup dump_name_2021-01-01..backup.gz" to copy particular backup
 # "just get-backup" to copy directory (backups) with all dumps
-get-backup *args:
+mount-docker-backup *args:
   docker cp app_db:/backups/{{args}} ./{{args}}
 
 restore *args:

--- a/justfile
+++ b/justfile
@@ -16,6 +16,9 @@ ps:
 exec *args:
   docker-compose exec app {{args}}
 
+logs *args:
+    docker-compose logs {{args}} -f
+
 mm *args:
   docker compose exec app alembic revision --autogenerate -m "{{args}}"
 

--- a/justfile
+++ b/justfile
@@ -34,3 +34,15 @@ ruff *args:
 
 lint:
   just ruff --fix
+
+backup:
+  docker compose exec app_db scripts/backup
+
+# examples:
+# "just get-backup dump_name_2021-01-01..backup.gz" to copy particular backup
+# "just get-backup" to copy directory (backups) with all dumps
+get-backup *args:
+  docker cp app_db:/backups/{{args}} ./{{args}}
+
+restore *args:
+    docker compose exec app_db scripts/restore {{args}}

--- a/scripts/postgres/backup
+++ b/scripts/postgres/backup
@@ -1,0 +1,17 @@
+#!/bin/sh -e
+
+echo "Backup process started."
+
+export POSTGRES_USER="${POSTGRES_USER}"
+
+# Save the current date in YYYY-MM-DD format to a variable
+current_datetime=$(date +%Y-%m-%d-%H%M%S)
+
+backup_directory="/backups"
+backup_filename="${backup_directory}/backup-${current_datetime}.dump.gz"
+
+# Run pg_dump and compress its output, then save to /backups with the current date in the filename
+pg_dump -Fc app -U "$POSTGRES_USER" | gzip > "$backup_filename"
+
+
+echo "Backup has been created and saved to ${backup_filename}"

--- a/scripts/postgres/restore
+++ b/scripts/postgres/restore
@@ -34,3 +34,5 @@ createdb "$POSTGRES_DB" --owner="$POSTGRES_USER" -U "$POSTGRES_USER"
 
 echo "Applying the backup to the new database..."
 gunzip -c "${full_file_path}" | pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+
+echo "Backup applied successfully."

--- a/scripts/postgres/restore
+++ b/scripts/postgres/restore
@@ -1,0 +1,36 @@
+#!/bin/sh -e
+
+# The directory where backups are stored
+BACKUP_DIRECTORY="/backups"
+
+# Check if a file name was provided as a parameter
+if [ $# -eq 0 ]; then
+  echo "No file name provided. Please provide a file name to check."
+  exit 1
+fi
+
+# The file name is taken from the first argument provided to the script
+file_name="$1"
+
+# Full path to the file
+full_file_path="${BACKUP_DIRECTORY}/${file_name}"
+
+# Check if the file exists
+if [ -f "$full_file_path" ]; then
+  echo "File ${file_name} exists."
+else
+  echo "File ${file_name} does not exist."
+  exit 1
+fi
+
+export POSTGRES_USER="${POSTGRES_USER}"
+export POSTGRES_DB="${POSTGRES_DB}"
+
+echo "Dropping the database..."
+dropdb "$POSTGRES_DB" -U "$POSTGRES_USER"
+
+echo "Creating a new database..."
+createdb "$POSTGRES_DB" --owner="$POSTGRES_USER" -U "$POSTGRES_USER"
+
+echo "Applying the backup to the new database..."
+gunzip -c "${full_file_path}" | pg_restore -U "$POSTGRES_USER" -d "$POSTGRES_DB"


### PR DESCRIPTION
## Changes
This PR introduces a new shortcut in the justfile that allows users to easily access `docker-compose` logs.
The shortcut can be used with the command `just logs` to display logs from all containers, or with an additional argument, such as `just logs app`, to view logs from the **app** container specifically.