### PR TITLE
Justfile additions and dev-deps completion

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ default:
 up:
   docker-compose up -d
 
+down:
+  docker-compose down
+
 kill:
   docker-compose kill
 
@@ -20,7 +23,7 @@ logs *args:
     docker-compose logs {{args}} -f
 
 mm *args:
-  docker compose exec app alembic revision --autogenerate -m "{{args}}"
+  docker compose exec app scripts/makemigrations {{args}}
 
 migrate:
   docker compose exec app alembic upgrade head
@@ -50,3 +53,5 @@ restore *args:
 test *args:
     docker compose exec app pytest {{args}}
 
+test-watch *args:
+    docker compose exec app ptw {{args}}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,8 +1,10 @@
 -r base.txt
 ruff==0.1.3
+black==24.2.0
 coverage==7.3.0
 mypy==1.5.1
 pytest==7.4.0
+pytest-watch==4.2.0
 pytest-asyncio==0.21.1
 async-asgi-testclient==1.4.11
 pytest-env==1.0.1


### PR DESCRIPTION
Makemigrations use the corresponding script now. Black added as dev dep for makemigrations not to error. Added down and test-watch to justfile, including pytest-watch in dev deps.
