### PR TITLE
change client fixture func name to differ from the returned obj name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,8 @@ def event_loop() -> Generator[asyncio.AbstractEventLoop, None, None]:
     loop.close()
 
 
-@pytest_asyncio.fixture
-async def client() -> AsyncGenerator[TestClient, None]:
+@pytest_asyncio.fixture(name="client")
+async def client_fixture() -> AsyncGenerator[TestClient, None]:
     host, port = "127.0.0.1", "9000"
     scope = {"client": (host, port)}
 


### PR DESCRIPTION
The `client` test fixture returns a `TestClient()` instance as `client` which is also the name of the fixture.

Rename function name to `client_fixture` for clarity while keeping fixture name as `client` to be referenced in tests