### PR TITLE
sentry initialize before app has been initialized

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,11 @@ async def lifespan(_application: FastAPI) -> AsyncGenerator:
     yield
     # Shutdown
 
+if settings.ENVIRONMENT.is_deployed:
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.ENVIRONMENT,
+    )
 
 app = FastAPI(**app_configs, lifespan=lifespan)
 
@@ -25,12 +30,6 @@ app.add_middleware(
     allow_methods=("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"),
     allow_headers=settings.CORS_HEADERS,
 )
-
-if settings.ENVIRONMENT.is_deployed:
-    sentry_sdk.init(
-        dsn=settings.SENTRY_DSN,
-        environment=settings.ENVIRONMENT,
-    )
 
 
 @app.get("/healthcheck", include_in_schema=False)


### PR DESCRIPTION
follow sentry's suggestion and example,
put init before app has been initialized

> If you have the fastapi package in your dependencies, the FastAPI integration will be enabled automatically when you initialize the Sentry SDK. Initialize the Sentry SDK before your app has been initialized:

```
from fastapi import FastAPI
import sentry_sdk

sentry_sdk.init(
    dsn="https://foo.ingest.us.sentry.io/bar",
    # Add data like request headers and IP for users,
    # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
    send_default_pii=True,
)

app = FastAPI()
```