### PR TITLE
fix: convert line endings from CRLF to LF in bash scripts

### DIFF
--- a/entrypoints/gunicorn.sh
+++ b/entrypoints/gunicorn.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Fixes #25. The bash script had Windows-style line endings (CRLF) which caused /usr/bin/env: 'bash\r' error on first run. Changed to LF.